### PR TITLE
Version to "2019.02.09-last-master-before-hyphenopoly"

### DIFF
--- a/hyphenateghsvs.xml
+++ b/hyphenateghsvs.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 3 or later; see LICENSE.txt; see also LICENSE_Hyphenator.txt</license>
 	<authorEmail></authorEmail>
 	<authorUrl>http://www.ghsvs.de</authorUrl>
-	<version>2017.11.29</version>
+	<version>2019.02.09-last-master-before-hyphenopoly</version>
 	<versionHistory>
 2016.02.28:
 - First version.


### PR DESCRIPTION
Just a final backup before we integrate Hyphenopoly.