### PR TITLE
Correct add_hypenate_css

### DIFF
--- a/hyphenateghsvs.php
+++ b/hyphenateghsvs.php
@@ -165,9 +165,10 @@ class PlgSystemhyphenateghsvs extends CMSPlugin
 
 		if ($this->params->get('add_hypenate_css', 0))
 		{
-			$doc->addStyleDeclaration(str_replace(array("\n", "\t"), '', file_get_contents(
-				JPATH_SITE . '/media/' . self::$basepath . '/css/hyphenate.css')
-			));
+			$add_hypenate_css = file_get_contents(
+				JPATH_SITE . '/media/' . self::$basepath . '/css/hyphenate.min.css'
+			);
+			$doc->addCustomTag('<style>' . $add_hypenate_css . '</style>');
 		}
 
 		JLoader::register('PlghyphenateghsvsHelper', __DIR__ . '/helper.php');

--- a/media/css/hyphenate.min.css
+++ b/media/css/hyphenate.min.css
@@ -1,0 +1,1 @@
+.hyphenate{word-wrap:break-word;-webkit-hyphens:auto;-moz-hyphens:auto;-ms-hyphens:auto;-o-hyphens:auto;hyphens:auto}.donthyphenate{word-wrap:break-word;-webkit-hyphens:none;-moz-hyphens:none;-ms-hyphens:none;-o-hyphens:none;hyphens:none}


### PR DESCRIPTION
The devil knows why. We had a template of j51 (j51_robyn) where the old lines
```
$doc->addStyleDeclaration(file_get_contents(... css/hyphenate.css));
```
included the complete content of the file correctly in the HEAD of the template but always the first selector [in the css file](https://github.com/GHSVS-de/plg_system_hyphenateghsvs/blob/master/media/css/hyphenate.css) was ignored by the browser / inspector (Vivaldi, FireFox) like it wouldn't exist.

All works fine with Protostar and Joomla 3.9.3.

After 2h I'm giving up and use addCustomTag(...) now.